### PR TITLE
Fix Folia compatibility in WorldTimeTracking

### DIFF
--- a/src/main/java/me/playbosswar/cmtplayerconditions/utils/WorldTimeTracking.java
+++ b/src/main/java/me/playbosswar/cmtplayerconditions/utils/WorldTimeTracking.java
@@ -8,29 +8,27 @@ import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.plugin.Plugin;
-import org.bukkit.scheduler.BukkitRunnable;
+import me.playbosswar.com.CommandTimerPlugin;
+import org.bukkit.scheduler.BukkitTask;
 
 import java.util.HashMap;
 import java.util.Map;
 
 public class WorldTimeTracking implements Listener {
-    private final BukkitRunnable runnable;
+    private BukkitTask task;
     private final Map<Player, Integer> secondsInWorld = new HashMap<>();
 
     public WorldTimeTracking(Plugin plugin) {
         Bukkit.getPluginManager().registerEvents(this, plugin);
-        runnable = new BukkitRunnable() {
-            @Override
-            public void run() {
-                secondsInWorld.forEach((player, value) -> secondsInWorld.put(player, value + 1));
-            }
-        };
-
-        runnable.runTaskTimer(plugin, 10L, 20L);
+        task = CommandTimerPlugin.getScheduler().runTaskTimer(() -> {
+            secondsInWorld.forEach((player, value) -> secondsInWorld.put(player, value + 1));
+        }, 10L, 20L);
     }
 
     public void cancel() {
-        runnable.cancel();
+        if (task != null) {
+            task.cancel();
+        }
     }
 
     @EventHandler


### PR DESCRIPTION
Replaced BukkitRunnable with CommandTimerPlugin.getScheduler() to support Folia's region threading model and fix issue  [#11](https://github.com/titivermeesch/CommandTimer_PlayerConditions/issues/11)

NOTE: This resolves the NullPointerException on startup. IMPORTANT: Other CommandTimer extensions should also be audited for BukkitRunnable usage, as they will likely fail on Folia servers for the same reason.